### PR TITLE
Fix: Resolve Tkinter layout conflict in GUI

### DIFF
--- a/reporter/gui.py
+++ b/reporter/gui.py
@@ -86,7 +86,7 @@ class App(customtkinter.CTk):
         """Sets up the frame for adding personal training bookings."""
         self.pt_booking_frame = CTkFrame(parent_frame, corner_radius=0, fg_color="transparent")
         # self.pt_booking_frame.grid(row=2, column=0, sticky="nsew", padx=20, pady=10) # Using pack instead
-        self.pt_booking_frame.pack(fill="x", expand=False, padx=20, pady=(10,0))
+        self.pt_booking_frame.grid(row=2, column=0, padx=5, pady=10, sticky="new")
 
 
         CTkLabel(self.pt_booking_frame, text="Add Personal Training Booking", font=CTkFont(size=16, weight="bold")).pack(pady=(0,10), anchor="w")


### PR DESCRIPTION
Changed pt_booking_frame in reporter/gui.py to use .grid() instead of .pack() to resolve a TclError caused by mixing layout managers within the same parent widget.

Verified that the database schema for 'plans' table and the DB_FILE import in migrate_data.py were already correct and aligned with the issue resolutions.