### PR TITLE
Implement Monthly Book Closing Feature

### DIFF
--- a/reporter/database.py
+++ b/reporter/database.py
@@ -49,6 +49,14 @@ def create_database(db_name: str):
             FOREIGN KEY (plan_id) REFERENCES plans (plan_id)
         );
         """)
+
+        # Create monthly_book_status table
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS monthly_book_status (
+            month_key TEXT PRIMARY KEY, -- Format: "YYYY-MM", e.g., "2025-07"
+            status TEXT NOT NULL      -- Values: "open" or "closed"
+        );
+        """)
         conn.commit()
         print(f"Database '{db_name}' created and tables ensured.")
     except sqlite3.Error as e:

--- a/reporter/simulations/simulate_book_closing_flow.py
+++ b/reporter/simulations/simulate_book_closing_flow.py
@@ -1,0 +1,155 @@
+# reporter/simulations/simulate_book_closing_flow.py
+
+import os
+import sys
+from datetime import datetime
+
+# Correctly adjust sys.path to enable imports from the 'reporter' package and its parent
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, project_root)
+
+from reporter.database import create_database
+from reporter.gui import GuiController
+from reporter import database_manager # Import the module itself for monkeypatching
+
+# --- Simulation Config ---
+# Place sim_data inside reporter/simulations/
+SIM_DB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sim_data")
+SIM_DB_FILE = os.path.join(SIM_DB_DIR, "simulation_kranos_data_book_closing.db")
+
+TEST_MEMBER_NAME = "Sim Member BookClose"
+TEST_MEMBER_PHONE = "SIMBC001"
+TEST_YEAR = 2030
+TEST_MONTH = 8 # August
+TEST_MONTH_KEY = f"{TEST_YEAR:04d}-{TEST_MONTH:02d}"
+PAYMENT_DATE_1 = f"{TEST_YEAR:04d}-{TEST_MONTH:02d}-10"
+PAYMENT_DATE_2 = f"{TEST_YEAR:04d}-{TEST_MONTH:02d}-15"
+AMOUNT_PAID_STR = "100.00"
+PAYMENT_METHOD_GC = "SimPayGC"
+
+original_db_file_path = None
+
+def setup_simulation_environment():
+    """Sets up a clean database for the simulation."""
+    global original_db_file_path
+    print(f"--- Setting up simulation environment ---")
+    print(f"Simulation Database: {SIM_DB_FILE}")
+    os.makedirs(SIM_DB_DIR, exist_ok=True)
+    if os.path.exists(SIM_DB_FILE):
+        os.remove(SIM_DB_FILE)
+
+    original_db_file_path = database_manager.DB_FILE
+    database_manager.DB_FILE = SIM_DB_FILE
+
+    create_database(SIM_DB_FILE)
+    print(f"Simulation database created and initialized at {SIM_DB_FILE}")
+    print(f"Database manager is now using: {database_manager.DB_FILE}")
+
+def run_simulation():
+    """Runs the book closing UI flow simulation."""
+    print(f"\n--- Starting Book Closing Flow Simulation ---")
+    controller = GuiController()
+
+    print(f"\nStep 1: Adding test member and fetching plan...")
+    success, msg = controller.save_member_action(TEST_MEMBER_NAME, TEST_MEMBER_PHONE)
+    assert success, f"Failed to add test member '{TEST_MEMBER_NAME}': {msg}"
+    print(f"Test member '{TEST_MEMBER_NAME}' added: {msg}")
+
+    member_details = database_manager.get_member_by_phone(TEST_MEMBER_PHONE)
+    assert member_details, f"Could not retrieve test member '{TEST_MEMBER_PHONE}' after adding."
+    member_id, _ = member_details
+    print(f"Test member ID: {member_id}")
+
+    active_plans = controller.get_active_plans()
+    assert active_plans, "No active plans found. Cannot proceed with simulation."
+    plan_id = active_plans[0][0]
+    print(f"Using plan ID: {plan_id}")
+
+    print(f"\nStep 2: Adding initial transaction to month {TEST_MONTH_KEY}...")
+    db_setup_success = database_manager.set_book_status(TEST_MONTH_KEY, "open")
+    assert db_setup_success, f"Failed to ensure book status is 'open' for {TEST_MONTH_KEY} at setup."
+    print(f"Ensured book status for {TEST_MONTH_KEY} is 'open' before first transaction.")
+
+    success, msg = controller.save_membership_action(
+        membership_type="Group Class",
+        member_id=member_id,
+        start_date_str=PAYMENT_DATE_1,
+        amount_paid_str=AMOUNT_PAID_STR,
+        selected_plan_id=plan_id,
+        payment_date_str=PAYMENT_DATE_1,
+        payment_method=PAYMENT_METHOD_GC
+    )
+    assert success, f"Failed to add initial transaction: {msg}"
+    print(f"Initial transaction added: {msg}")
+
+    print(f"\nStep 3: Closing books for month {TEST_MONTH_KEY}...")
+    success, msg = controller.close_books_action(TEST_YEAR, TEST_MONTH)
+    assert success, f"Failed to close books: {msg}"
+    print(f"Books closed action: {msg}")
+
+    status_msg = controller.get_book_status_action(TEST_YEAR, TEST_MONTH)
+    print(f"Status check: {status_msg}")
+    assert f"Status for {TEST_MONTH_KEY}: closed" in status_msg.lower(), f"Books for {TEST_MONTH_KEY} should be 'closed', but status is: {status_msg}"
+
+    print(f"\nStep 4: Attempting to add transaction to {TEST_MONTH_KEY} (now closed)...")
+    success, msg = controller.save_membership_action(
+        membership_type="Group Class",
+        member_id=member_id,
+        start_date_str=PAYMENT_DATE_2,
+        amount_paid_str=AMOUNT_PAID_STR,
+        selected_plan_id=plan_id,
+        payment_date_str=PAYMENT_DATE_2,
+        payment_method=PAYMENT_METHOD_GC
+    )
+    assert not success, f"Should have failed to add transaction to closed month, but succeeded: {msg}"
+    print(f"Attempt to add to closed month: {msg}")
+    expected_fail_msg_part = f"books for {TEST_MONTH_KEY} are closed"
+    assert expected_fail_msg_part in msg.lower(), f"Failure message '{msg}' did not contain expected part '{expected_fail_msg_part}'"
+
+    print(f"\nStep 5: Re-opening books for month {TEST_MONTH_KEY}...")
+    success, msg = controller.open_books_action(TEST_YEAR, TEST_MONTH)
+    assert success, f"Failed to re-open books: {msg}"
+    print(f"Books re-opened action: {msg}")
+
+    status_msg = controller.get_book_status_action(TEST_YEAR, TEST_MONTH)
+    print(f"Status check: {status_msg}")
+    assert f"Status for {TEST_MONTH_KEY}: open" in status_msg.lower(), f"Books for {TEST_MONTH_KEY} should be 'open', but status is: {status_msg}"
+
+    print(f"\nStep 6: Attempting to add transaction to {TEST_MONTH_KEY} (now open)...")
+    success, msg = controller.save_membership_action(
+        membership_type="Group Class",
+        member_id=member_id,
+        start_date_str=PAYMENT_DATE_2,
+        amount_paid_str=AMOUNT_PAID_STR,
+        selected_plan_id=plan_id,
+        payment_date_str=PAYMENT_DATE_2,
+        payment_method=PAYMENT_METHOD_GC
+    )
+    assert success, f"Failed to add transaction to re-opened month: {msg}"
+    print(f"Transaction added to re-opened month: {msg}")
+
+    print(f"\n--- Book Closing Flow Simulation Completed Successfully ---")
+
+def cleanup_simulation_environment():
+    """Cleans up by restoring DB_FILE path."""
+    global original_db_file_path
+    print(f"\n--- Simulation cleanup ---")
+    if original_db_file_path:
+        database_manager.DB_FILE = original_db_file_path
+        print(f"Restored database_manager.DB_FILE to: {database_manager.DB_FILE}")
+
+if __name__ == "__main__":
+    try:
+        setup_simulation_environment()
+        run_simulation()
+    except AssertionError as e:
+        print(f"\n--- SIMULATION FAILED: {e} ---", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n--- SIMULATION ERRORED UNEXPECTEDLY: {e} ---", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(2)
+    finally:
+        cleanup_simulation_environment()
+        print(f"--- Simulation script finished ---")

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -32,6 +32,7 @@ SIMULATION_SUCCESS=true # Flag to track overall simulation success
 
 # Check if simulation directory exists
 if [ -d "${SIMULATION_SCRIPTS_DIR}" ]; then
+    # This loop runs all python scripts starting with 'simulate_' in the ${SIMULATION_SCRIPTS_DIR}
     for script in ${SIMULATION_SCRIPTS_DIR}/simulate_*.py; do
         if [ -f "${script}" ]; then
             echo "


### PR DESCRIPTION
This commit introduces a system to "close the books" for a specific month, preventing any additions, edits, or deletions of transactions within that month.

Key changes include:

1.  **Database Schema:**
    *   Added a new table `monthly_book_status` to `reporter/database.py` to store the status (open/closed) for each month (YYYY-MM).

2.  **Backend Logic (`reporter/database_manager.py`):**
    *   Implemented `get_book_status(month_key)` to retrieve the status of a given month.
    *   Implemented `set_book_status(month_key, status)` to set a month's status to "open" or "closed".
    *   Added guard clauses to `add_transaction` and `delete_transaction` to prevent modifications if the relevant month's books are closed. These functions now return a tuple `(bool, message)`.

3.  **User Interface (`reporter/gui.py`):**
    *   Added a "Monthly Book Closing" section to the "Reporting" tab.
    *   You can select a year and month to check status, close books, or re-open books.
    *   Implemented corresponding actions in `GuiController` to handle these UI interactions and call the backend logic.

4.  **Testing:**
    *   Added unit tests in `reporter/tests/test_database_manager.py` for the new `get_book_status`, `set_book_status` functions and to verify the behavior of transaction functions when books are closed or open.
    *   Created a new UI flow simulation script `reporter/simulations/simulate_book_closing_flow.py` to test the end-to-end book closing process.
    *   Updated `run_all_tests.sh` to include the new simulation script (verified auto-inclusion via wildcard and added a clarifying comment).

This feature enhances financial control by allowing administrators to finalize monthly records.