### PR TITLE
Fix: Correct dependencies and resolve ImportError

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A desktop application designed to manage gym operations, including memberships, 
 
 ## Technology Stack
 * **Language**: Python 3
-* **GUI**: CustomTkinter
+* **GUI**: Flet
 * **Database**: SQLite
 * **Testing**: pytest
 
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS transactions (
 ```
 /reporter/
 |-- main.py                 # Main application entry point
-|-- gui.py                  # Defines the CustomTkinter GUI
+|-- gui.py                  # Defines the Flet GUI
 |-- database.py             # Defines the database schema and setup
 |-- database_manager.py     # Handles all database CRUD operations
 |-- migrate_data.py         # Script to migrate data from CSV files
@@ -85,12 +85,15 @@ CREATE TABLE IF NOT EXISTS transactions (
 
 ## Setup and Run
 1.  Ensure you have Python 3 installed.
-2.  Place your data files (`Kranos MMA Members.xlsx - GC.csv` and `Kranos MMA Members.xlsx - PT.csv`) in the root directory of the project if you wish to use the data migration script.
-3.  Run the application by executing the `main.py` script:
+2.  Install the required dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+3.  Place your data files (`Kranos MMA Members.xlsx - GC.csv` and `Kranos MMA Members.xlsx - PT.csv`) in the root directory of the project if you wish to use the data migration script.
+4.  Run the application by executing the `main.py` script:
     ```bash
     python reporter/main.py
     ```
-4.  The application will automatically check for and install the required `customtkinter` dependency on the first run.
 
 ## Data Migration
 The `migrate_data.py` script is provided to import existing member data from CSV files into the database.

--- a/reporter/main.py
+++ b/reporter/main.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 import importlib.util
 import flet as ft # Added Flet import
-from reporter.database_manager import initialize_database, DB_FILE # Updated database import
+from reporter.database import initialize_database, DB_FILE # Updated database import
 from reporter.gui import main as start_flet_gui # Import main from the new gui.py
 
 # Removed old imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-customtkinter
-tkcalendar
+flet
 pandas
 openpyxl
-flet
+pytest


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Updates `requirements.txt`**: Removes outdated packages (customtkinter, tkcalendar) and includes the necessary dependencies for the Flet-based UI (flet, pandas, openpyxl, pytest).
2.  **Fixes `ImportError` in `main.py`**: Corrects an import statement in `reporter/main.py` that was causing a startup crash. The import for `initialize_database` and `DB_FILE` now correctly points to `reporter.database` instead of `reporter.database_manager`.

Additionally, the `README.md` file has been updated to:
- Reflect Flet as the current GUI framework in the Technology Stack.
- Update the file structure description for `gui.py`.
- Modify the "Setup and Run" instructions, including the command to install dependencies from `requirements.txt` and removing the outdated note about automatic customtkinter installation.