### PR TITLE
Fix: Resolve ImportError and refactor database initialization

### DIFF
--- a/reporter/tests/test_database.py
+++ b/reporter/tests/test_database.py
@@ -1,6 +1,7 @@
 import sqlite3
 import pytest
-from reporter.database import create_database, seed_initial_plans
+import os # Added os import
+from reporter.database import create_database, seed_initial_plans, initialize_database, DB_FILE as ORIGINAL_DB_FILE # Import initialize_database and original DB_FILE
 
 # Expected table names
 EXPECTED_TABLES = ["members", "plans", "transactions", "monthly_book_status"]
@@ -76,3 +77,73 @@ if __name__ == '__main__':
     # This allows running tests directly with `python reporter/tests/test_database.py`
     # though `pytest` is the recommended way.
     pytest.main()
+
+def test_initialize_database_runs_without_error(monkeypatch, tmp_path):
+    """
+    Tests if initialize_database function runs without error, creates the DB and tables,
+    and seeds initial plans, using a temporary database file.
+    """
+    # Define a temporary database path within pytest's tmp_path fixture
+    test_db_name = "test_temp_init.db"
+    test_db_dir = tmp_path / "data" # Use a subdirectory within tmp_path
+    test_db_file = test_db_dir / test_db_name
+
+    # Monkeypatch reporter.database.DB_FILE to this test_db_file
+    monkeypatch.setattr('reporter.database.DB_FILE', str(test_db_file))
+
+    # Ensure the target directory for the test_db_file does not exist initially
+    # initialize_database should create it.
+    if os.path.exists(test_db_dir):
+        # If we want to ensure initialize_database creates the directory,
+        # we might remove it here. However, initialize_database itself has logic
+        # to create os.path.dirname(DB_FILE). Let's rely on that.
+        # For the DB file itself, initialize_database calls create_database,
+        # which will create a new DB or open existing.
+        # Let's ensure the DB file specifically is gone.
+        if os.path.exists(test_db_file):
+            os.remove(test_db_file)
+
+    conn = None
+    try:
+        # Call initialize_database()
+        # This should create the directory (if not exists), db, tables, and seed plans.
+        initialize_database()
+
+        # Assert that the test_db_file now exists
+        assert os.path.exists(test_db_file), f"Database file '{test_db_file}' was not created."
+
+        # Connect to test_db_file and verify tables and initial plans
+        conn = sqlite3.connect(test_db_file)
+        cursor = conn.cursor()
+
+        # Verify tables
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables_in_test_db = [row[0] for row in cursor.fetchall()]
+        for table_name in EXPECTED_TABLES: # Assuming EXPECTED_TABLES is defined globally in this file
+            assert table_name in tables_in_test_db, f"Table '{table_name}' not found in temporary database."
+
+        # Verify initial plans
+        cursor.execute("SELECT plan_name, duration_days FROM plans ORDER BY duration_days;")
+        seeded_plans_in_test_db = cursor.fetchall()
+        assert len(seeded_plans_in_test_db) == len(EXPECTED_INITIAL_PLANS), \
+            f"Expected {len(EXPECTED_INITIAL_PLANS)} plans, but found {len(seeded_plans_in_test_db)}."
+
+        for i, expected_plan in enumerate(EXPECTED_INITIAL_PLANS): # Assuming EXPECTED_INITIAL_PLANS is defined
+            assert seeded_plans_in_test_db[i][0] == expected_plan[0], \
+                f"Plan name mismatch: Expected '{expected_plan[0]}', got '{seeded_plans_in_test_db[i][0]}'"
+            assert seeded_plans_in_test_db[i][1] == expected_plan[1], \
+                f"Plan duration mismatch for '{expected_plan[0]}': Expected {expected_plan[1]}, got {seeded_plans_in_test_db[i][1]}"
+
+    except Exception as e:
+        pytest.fail(f"initialize_database test failed: {e}")
+    finally:
+        if conn:
+            conn.close()
+        # Cleanup: pytest's tmp_path fixture handles directory cleanup automatically.
+        # If test_db_file was outside tmp_path, manual os.remove(test_db_file) and possibly os.rmdir() would be needed.
+        # Since we are using tmp_path, this is mostly handled.
+        # We explicitly removed test_db_file if it existed before the test.
+        # initialize_database creates DB_FILE in dirname(DB_FILE)
+        # So if test_db_dir was created by the test, tmp_path cleans it.
+        # If test_db_file specifically needs removal and it's not in tmp_path, do it here.
+        # For now, relying on tmp_path for cleanup of test_db_dir and its contents.

--- a/reporter/tests/test_main.py
+++ b/reporter/tests/test_main.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import subprocess
+import pytest # Using pytest for consistency if other tests use it, can also use unittest.mock
+from unittest.mock import patch, MagicMock
+
+# Add project root to sys.path to allow direct import of reporter.main
+# This might be needed if running pytest from the root or if PYTHONPATH isn't set up
+# Adjust path as necessary based on your test execution environment
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+# Now we can import the function from reporter.main
+try:
+    from reporter.main import handle_database_migration
+except ImportError as e:
+    # This might happen if the path isn't set correctly or if there's an issue in main.py
+    # For testing purposes, we'll raise a more informative error.
+    raise ImportError(f"Could not import handle_database_migration from reporter.main. Error: {e}. Check sys.path and reporter/main.py.")
+
+
+# Determine the expected path to migrate_data.py relative to main.py
+# Assuming main.py is in 'reporter/' directory.
+# __file__ for test_main.py is reporter/tests/test_main.py
+# main_py_dir would be os.path.dirname(reporter.main.__file__) if reporter.main could be imported to get __file__
+# For now, let's assume reporter.main.__file__ would be <some_path>/reporter/main.py
+# So, os.path.dirname(reporter.main.__file__) is <some_path>/reporter
+# And the migrate_script_path is <some_path>/reporter/migrate_data.py
+
+# To robustly get the directory of main.py without importing it directly for its __file__ at module level:
+# We are testing the *function* handle_database_migration, which itself uses __file__ (referring to main.py)
+# So, the patches need to target 'reporter.main.os.path.exists', etc.
+# The argument to os.path.exists in the original function is:
+# os.path.join(os.path.dirname(__file__), 'migrate_data.py') where __file__ is main.py's path.
+
+# We need to determine what that path would be for assertion.
+# Let's assume the test runner is smart enough or that the path for `reporter.main.__file__`
+# will be correctly resolved when the function `handle_database_migration` is called.
+# The key is that `patch` targets names in the module where they are looked up.
+# `handle_database_migration` looks up `os.path.exists` in `reporter.main`'s scope.
+
+EXPECTED_MIGRATE_SCRIPT_PATH_IN_MAIN = 'reporter/migrate_data.py' # This needs to be accurate based on main.py's __file__
+
+@patch('reporter.main.subprocess.run')
+@patch('reporter.main.os.path.exists')
+def test_migration_runs_if_script_exists(mock_exists, mock_run):
+    """
+    Tests that the migration script is run if it exists and returns success.
+    """
+    # Dynamically determine the expected path as it would be calculated in handle_database_migration
+    # This assumes reporter.main module can be found and has a __file__ attribute.
+    # This part is tricky because reporter.main might not be fully imported if it has top-level code for Flet.
+    # For the purpose of this test, we'll assume that when handle_database_migration is called,
+    # os.path.dirname(__file__) within that function correctly points to the 'reporter' directory.
+    # The assertion for mock_exists.assert_called_with(...) will verify this.
+
+    mock_exists.return_value = True
+    mock_run.return_value = MagicMock(returncode=0, stdout="Migration successful", stderr="")
+
+    handle_database_migration()
+
+    # Assert that os.path.exists was called correctly
+    # The path used inside handle_database_migration is os.path.join(os.path.dirname(__file__), 'migrate_data.py')
+    # We need to know what os.path.dirname(__file__) will be from within reporter.main module.
+    # If main.py is in <root>/reporter/main.py, then dirname is <root>/reporter.
+    # For now, we trust the call within the function and check that it was called.
+    # A more robust way would be to import reporter.main and get its __file__ attribute.
+    # However, since we are patching os.path.exists *within* reporter.main, its internal call is what matters.
+    mock_exists.assert_called_once()
+    # The first argument of the first call to mock_exists:
+    called_path_for_exists = mock_exists.call_args[0][0]
+    assert called_path_for_exists.endswith('reporter/migrate_data.py'), \
+        f"os.path.exists called with unexpected path: {called_path_for_exists}"
+
+
+    mock_run.assert_called_once_with(
+        [sys.executable, '-m', 'reporter.migrate_data'],
+        capture_output=True, text=True, check=False
+    )
+
+@patch('reporter.main.subprocess.run')
+@patch('reporter.main.os.path.exists')
+def test_migration_handles_failure(mock_exists, mock_run, capsys):
+    """
+    Tests that a failure in the migration script (non-zero return code) is handled.
+    """
+    mock_exists.return_value = True
+    mock_run.return_value = MagicMock(returncode=1, stdout="Output before error", stderr="Migration error details")
+
+    handle_database_migration()
+
+    mock_exists.assert_called_once()
+    called_path_for_exists = mock_exists.call_args[0][0]
+    assert called_path_for_exists.endswith('reporter/migrate_data.py')
+
+
+    mock_run.assert_called_once_with(
+        [sys.executable, '-m', 'reporter.migrate_data'],
+        capture_output=True, text=True, check=False
+    )
+
+    # Check if error messages were printed (optional, but good for CLI tools)
+    captured = capsys.readouterr()
+    assert "Data migration script failed with error" in captured.out
+    assert "Migration error details" in captured.out
+    assert "Output before error" in captured.out # stdout should also be printed
+
+@patch('reporter.main.subprocess.run')
+@patch('reporter.main.os.path.exists')
+def test_migration_skipped_if_script_missing(mock_exists, mock_run, capsys):
+    """
+    Tests that the migration script is skipped if it does not exist.
+    """
+    mock_exists.return_value = False
+
+    handle_database_migration()
+
+    mock_exists.assert_called_once()
+    called_path_for_exists = mock_exists.call_args[0][0]
+    assert called_path_for_exists.endswith('reporter/migrate_data.py')
+
+    mock_run.assert_not_called()
+
+    # Check if skipping message was printed
+    captured = capsys.readouterr()
+    assert "not found. Skipping migration" in captured.out
+
+# To run these tests with pytest, navigate to the directory containing 'reporter'
+# and run `pytest`. Ensure __init__.py files are in 'reporter' and 'reporter/tests'.
+# Example: if project root is 'my_project/', and tests are in 'my_project/reporter/tests/',
+# run `pytest` from 'my_project/'.
+# Make sure `PYTHONPATH` includes your project root or use editable install (`pip install -e .`).
+# The sys.path.insert above helps, but proper packaging or PYTHONPATH is more robust.
+# The test file should be named test_*.py or *_test.py for pytest to discover it.
+# This file is named test_main.py, so it should be discovered.
+# Adding a simple `if __name__ == '__main__': pytest.main()` is also possible for direct run.
+if __name__ == '__main__':
+    pytest.main([__file__]) # Allows running this test file directly using pytest engine


### PR DESCRIPTION
This commit addresses an ImportError in `reporter/main.py` caused by an incorrect import of `initialize_database` from `reporter.database`.

Changes include:
- Moved `DB_FILE` in `reporter/database.py` to the module level to allow proper importing.
- Created a new `initialize_database` function in `reporter/database.py` that encapsulates database and table creation, data directory ensurement, and seeding of initial plans.
- Updated the `if __name__ == '__main__':` block in `reporter/database.py` to use the new `initialize_database` function.
- Modified `reporter/main.py`:
    - It now correctly imports and calls the new `initialize_database` function.
    - Added logic to conditionally run a data migration script (`reporter/migrate_data.py`) if it exists. This logic is encapsulated in a new `handle_database_migration` function.
- Added unit tests:
    - For `reporter.database.initialize_database` to ensure it runs correctly and sets up a temporary database as expected.
    - For `reporter.main.handle_database_migration` to verify the conditional migration logic, covering cases where the migration script exists (and succeeds or fails) or does not exist. This involved mocking `os.path.exists` and `subprocess.run`.

These changes make the database setup more robust, fix the runtime bug, and improve the overall structure and testability of the application's startup process.