### PR TITLE
I've updated the package versions in your `requirements.txt` file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flet
-pandas
-openpyxl
-pytest
+flet==0.28.3
+pandas==2.3.0
+openpyxl==3.1.5
+pytest==8.4.0


### PR DESCRIPTION
I've pinned the versions for flet, pandas, openpyxl, and pytest to the following:
- flet==0.28.3
- pandas==2.3.0
- openpyxl==3.1.5
- pytest==8.4.0