### PR TITLE
Fix: Update Streamlit launch command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ CREATE TABLE IF NOT EXISTS transactions (
 3.  Place your data files (`Kranos MMA Members.xlsx - GC.csv` and `Kranos MMA Members.xlsx - PT.csv`) in the root directory of the project if you wish to use the data migration script.
 4.  Run the application by executing the `main.py` script:
     ```bash
-    streamlit run reporter/streamlit_ui/app.py
+    python -m streamlit run reporter/streamlit_ui/app.py
     ```
 
 ## Data Migration


### PR DESCRIPTION
The README.md file has been updated to reflect the correct command for launching the Streamlit application.

The previous command `streamlit run reporter/streamlit_ui/app.py` could lead to a `ModuleNotFoundError` because the project root directory was not added to Python's path.

The new command `python -m streamlit run reporter/streamlit_ui/app.py` ensures that the application is run as a module, correctly adding the current directory (project root) to Python's path and resolving the import issue.