### PR TITLE
I fixed an ImportError in `migrate_data.py` that occurred when you ra…

### DIFF
--- a/reporter/migrate_data.py
+++ b/reporter/migrate_data.py
@@ -4,9 +4,22 @@ import sqlite3
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
+import os
+import sys
+
+if __name__ == '__main__' and __package__ is None:
+    # Get the directory of the current script (reporter/migrate_data.py)
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    # Get the parent directory (Salaries/) and add it to sys.path
+    parent_dir = os.path.dirname(script_dir)
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+    # Now we can use absolute imports from the reporter package
+    __package__ = "reporter"
+
 # Make sure the main database file is initialized
-from .database import create_database
-from .database_manager import DB_FILE, DatabaseManager
+from reporter.database import create_database
+from reporter.database_manager import DB_FILE, DatabaseManager
 
 # Determine the directory of the current script
 script_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
…n it directly.

Previously, your script `reporter/migrate_data.py` would fail with an `ImportError: attempted relative import with no known parent package` if you executed it directly using `python reporter/migrate_data.py`.

This happened because relative imports (like `from .database import ...`) only function correctly when the script is run as part of a package (for instance, using `python -m reporter.migrate_data`).

I've addressed this issue by making the following changes:
1. I added a check at the beginning of `reporter/migrate_data.py` to see if it's being run as the main script (`__name__ == '__main__'`) and if its package context (`__package__`) isn't set.
2. If those conditions are true, I ensured the script's parent directory (the project root, which I expect to be 'Salaries') is added to `sys.path`.
3. I explicitly set the `__package__` variable to "reporter".
4. I changed the import statements for `database` and `database_manager` from relative (`from .database`) to absolute (`from reporter.database`).

These adjustments allow you to run `reporter/migrate_data.py` directly, while still letting it function as a module when you run it with `python -m reporter.migrate_data` (as is done in `reporter/main.py`).