### PR TITLE
feat: Implement initial Members tab UI structure and form

### DIFF
--- a/project_management.md
+++ b/project_management.md
@@ -60,14 +60,14 @@ Goal: Rebuild the Streamlit UI with the new tabbed navigation.
 
 [x] Implement Tabbed Layout: In streamlit_ui/app.py, delete all old UI code and replace it with st.tabs(["Memberships", "Members", "Plans", "Reporting"]).
 
-[ ] Create Tab Functions: For better organization, create separate functions to render the content of each tab (e.g., render_memberships_tab(), etc.) and call them within their respective tabs.
+[x] Create Tab Functions: For better organization, create separate functions to render the content of each tab (e.g., render_memberships_tab(), etc.) and call them within their respective tabs.
 
 Phase 4: UI Build - "Members" Tab
 Goal: Implement the full functionality of the "Members" tab.
 
-[ ] Implement Layout: Create the two-column layout.
+[x] Implement Layout: Create the two-column layout.
 
-[ ] Build Left Form: Create the "Add/Edit Member" form with "Save" and "Clear" buttons.
+[x] Build Left Form: Create the "Add/Edit Member" form with "Save" and "Clear" buttons.
 
 [ ] Build Right Table & Filters:
 

--- a/reporter/streamlit_ui/app.py
+++ b/reporter/streamlit_ui/app.py
@@ -19,6 +19,54 @@ def get_db_connection():
 # For more complex scenarios, connection pooling or caching might be considered.
 api = AppAPI(get_db_connection()) # Example if kept
 
+# --- Tab Rendering Functions ---
+def render_memberships_tab():
+    st.header("Memberships Management")
+    # Placeholder content
+    st.write("Content for memberships management will go here.")
+
+def render_members_tab():
+    st.header("Member Management")
+    # Placeholder content
+    # st.write("Content for member management will go here.") # Original placeholder
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.header("Add/Edit Member")
+        # st.write("Form will go here.") # Original placeholder
+        with st.form(key='member_form'):
+            st.text_input("Name")
+            st.date_input("Join Date") # Consider default value: datetime.date.today()
+            st.text_input("Phone")
+            st.selectbox("Status", options=["active", "inactive"])
+
+            # Buttons
+            # As per subtask: two st.form_submit_button, acknowledging both will submit.
+            # Handling distinct "Clear" logic is a future step if required.
+            submit_button = st.form_submit_button("Save")
+            clear_button = st.form_submit_button("Clear")
+
+            if submit_button:
+                # Logic for saving will go here in a future task
+                st.success("Save button pressed (logic not implemented).")
+            if clear_button:
+                # Logic for clearing will go here / or this button might be changed
+                st.info("Clear button pressed (logic not implemented).")
+
+    with col2:
+        st.header("View Members")
+        st.write("Table and filters will go here.")
+
+def render_plans_tab():
+    st.header("Plan Management")
+    # Placeholder content
+    st.write("Content for plan management will go here.")
+
+def render_reporting_tab():
+    st.header("Reporting")
+    # Placeholder content
+    st.write("Content for reporting will go here.")
+
 st.set_page_config(layout="wide")
 st.title("Kranos MMA Reporter v2.0") # Update title if desired
 
@@ -28,21 +76,13 @@ tab_memberships, tab_members, tab_plans, tab_reporting = st.tabs([
 ])
 
 with tab_memberships:
-    st.header("Memberships Management")
-    # Placeholder content
-    st.write("Content for memberships management will go here.")
+    render_memberships_tab()
 
 with tab_members:
-    st.header("Member Management")
-    # Placeholder content
-    st.write("Content for member management will go here.")
+    render_members_tab()
 
 with tab_plans:
-    st.header("Plan Management")
-    # Placeholder content
-    st.write("Content for plan management will go here.")
+    render_plans_tab()
 
 with tab_reporting:
-    st.header("Reporting")
-    # Placeholder content
-    st.write("Content for reporting will go here.")
+    render_reporting_tab()


### PR DESCRIPTION
I've completed the following tasks from project_management.md:
- Phase 3: I created separate rendering functions for each tab in streamlit_ui/app.py for better organization.
- Phase 4 (Members Tab):
    - I implemented a two-column layout.
    - I built the 'Add/Edit Member' form in the left column with fields for Name, Join Date, Phone, and Status, including Save/Clear buttons.

These changes establish the basic UI structure for the Members tab, allowing for further development of member filtering, display, and interaction. All corresponding tasks in project_management.md have been updated.