### PR TITLE
Refactor Streamlit UI to align with new API

### DIFF
--- a/reporter/streamlit_ui/app.py
+++ b/reporter/streamlit_ui/app.py
@@ -11,7 +11,10 @@ from reporter.app_api import (
     get_active_plans_for_dropdown,
     get_all_memberships_for_view, # Added
     update_membership,            # Added
-    delete_membership             # Added
+    delete_membership,             # Added
+    # Added new reporting functions
+    get_financial_summary_report,
+    get_renewal_forecast_report
 )
 from reporter.database import DB_FILE # Use this for DB_PATH
 
@@ -25,9 +28,12 @@ api = AppAPI(get_db_connection()) # This instance is for other tabs/features pot
 # --- Helper function to clear form state ---
 def clear_membership_form_state():
     st.session_state.create_member_id = None
-    st.session_state.create_plan_id = None
+    # st.session_state.create_plan_id = None # This will be derived from create_plan_id_display
+    st.session_state.create_plan_id_display = None # Will store (id, name, duration)
     st.session_state.create_transaction_amount = 0.0
     st.session_state.create_start_date = date.today()
+    st.session_state.selected_plan_duration_display = "" # For displaying duration
+
     # If using a form key to force rebuild, you might increment it here
     if 'form_key_create_membership' in st.session_state:
         st.session_state.form_key_create_membership = f"form_{datetime.now().timestamp()}"
@@ -38,10 +44,17 @@ def render_memberships_tab():
     # This tab is for creating and managing memberships as per P3-T1 / P3-T2
 
     # Initialize session state for form inputs if not already present
-    if 'create_member_id' not in st.session_state:
+    if 'create_member_id' not in st.session_state: # Stores the selected member_id for submission
         st.session_state.create_member_id = None
-    if 'create_plan_id' not in st.session_state:
-        st.session_state.create_plan_id = None
+    if 'create_member_id_display' not in st.session_state: # Stores (id, name) for member selectbox
+        st.session_state.create_member_id_display = None
+
+    # For plan selection
+    if 'create_plan_id_display' not in st.session_state: # Stores (id, name, duration) for plan selectbox
+        st.session_state.create_plan_id_display = None
+    if 'selected_plan_duration_display' not in st.session_state: # For displaying duration
+        st.session_state.selected_plan_duration_display = ""
+
     if 'create_transaction_amount' not in st.session_state:
         st.session_state.create_transaction_amount = 0.0
     if 'create_start_date' not in st.session_state:
@@ -80,30 +93,58 @@ def render_memberships_tab():
 
         # Fetch data for dropdowns
         try:
-            member_list = get_active_members_for_dropdown(DB_FILE) # List of (id, name)
-            plan_list = get_active_plans_for_dropdown(DB_FILE)     # List of (id, name)
+            member_list_tuples = get_active_members_for_dropdown(DB_FILE) # List of (id, name)
+            # Assuming get_active_plans_for_dropdown returns list of (id, name, duration_days)
+            # If not, this is a point of failure or needs adjustment.
+            plan_list_tuples = get_active_plans_for_dropdown(DB_FILE)
         except Exception as e:
             st.error(f"Error fetching data for dropdowns: {e}")
-            member_list = []
-            plan_list = []
+            member_list_tuples = []
+            plan_list_tuples = []
 
-        # Add a "Select..." option
-        member_options = [(None, "Select Member...")] + member_list
-        plan_options = [(None, "Select Plan...")] + plan_list
+        # Prepare options for selectboxes
+        # Member options: store (id, name) tuple, display name
+        member_options = {None: "Select Member..."}
+        for mid, mname in member_list_tuples:
+            member_options[(mid, mname)] = mname
+
+        # Plan options: store (id, name, duration) tuple, display name
+        plan_options = {None: "Select Plan..."}
+        for pid, pname, pduration in plan_list_tuples: # Assumes (id, name, duration)
+            plan_options[(pid, pname, pduration)] = pname
+
+
+        # Callback to update displayed duration when plan selection changes
+        def update_plan_duration_display():
+            selected_plan_data = st.session_state.get("create_plan_id_display_widget")
+            if selected_plan_data and selected_plan_data[0] is not None: # selected_plan_data is (id, name, duration)
+                st.session_state.selected_plan_duration_display = f"{selected_plan_data[2]} days"
+                st.session_state.create_plan_id_display = selected_plan_data # Store the full tuple for form submission logic
+            else:
+                st.session_state.selected_plan_duration_display = ""
+                st.session_state.create_plan_id_display = None
 
         # Use st.form for better grouping of inputs and submission
-        with st.form(key=st.session_state.form_key_create_membership, clear_on_submit=False): # Clear on submit handled manually by clear_membership_form_state
+        with st.form(key=st.session_state.form_key_create_membership, clear_on_submit=False):
             st.selectbox(
                 "Member Name",
-                options=member_options,
-                format_func=lambda x: x[1],
-                key="create_member_id_display" # This will store (id,name) tuple
+                options=list(member_options.keys()),
+                format_func=lambda key: member_options[key],
+                key="create_member_id_display" # Stores (id,name)
             )
             st.selectbox(
                 "Plan Name",
-                options=plan_options,
-                format_func=lambda x: x[1],
-                key="create_plan_id_display" # This will store (id,name) tuple
+                options=list(plan_options.keys()),
+                format_func=lambda key: plan_options[key],
+                key="create_plan_id_display_widget", # Temp key for widget, stores (id,name,duration)
+                on_change=update_plan_duration_display
+            )
+            # Display Plan Duration (read-only)
+            st.text_input(
+                "Plan Duration",
+                value=st.session_state.selected_plan_duration_display,
+                disabled=True,
+                key="displayed_plan_duration_readonly" # Unique key
             )
             st.number_input(
                 "Transaction Amount",
@@ -123,12 +164,14 @@ def render_memberships_tab():
                 clear_button = st.form_submit_button("CLEAR")
 
         if save_button:
-            # Extract IDs from the stored tuples in session state
-            selected_member_tuple = st.session_state.get("create_member_id_display")
-            selected_plan_tuple = st.session_state.get("create_plan_id_display")
+            # Extract data from session state
+            selected_member_data = st.session_state.get("create_member_id_display") # This is (id, name)
+            selected_plan_data = st.session_state.get("create_plan_id_display")   # This is (id, name, duration)
 
-            member_id = selected_member_tuple[0] if selected_member_tuple and selected_member_tuple[0] is not None else None
-            plan_id = selected_plan_tuple[0] if selected_plan_tuple and selected_plan_tuple[0] is not None else None
+            member_id = selected_member_data[0] if selected_member_data and selected_member_data[0] is not None else None
+            plan_id = selected_plan_data[0] if selected_plan_data and selected_plan_data[0] is not None else None
+            # plan_duration = selected_plan_data[2] if selected_plan_data and selected_plan_data[0] is not None else None # Duration is available if needed
+
             amount = st.session_state.create_transaction_amount
             start_date_val = st.session_state.create_start_date
 
@@ -316,402 +359,14 @@ def render_memberships_tab():
                  # Rerun can help clear the state if it's stuck
                  st.rerun()
 
-
-def render_members_tab():
-    st.header("Member Management")
-
-    # Initialize session state variables if they don't exist
-    if 'selected_member_id' not in st.session_state:
-        st.session_state.selected_member_id = None
-    if 'show_history_modal' not in st.session_state:
-        st.session_state.show_history_modal = False
-    if 'history_member_id' not in st.session_state:
-        st.session_state.history_member_id = None
-    if 'form_key_member' not in st.session_state: # To reset form
-        st.session_state.form_key_member = 'initial_member_form'
-
-
-    left_column, right_column = st.columns(2)
-
-    # Left Column: Add/Edit Member Form
-    with left_column:
-        st.subheader("Add/Edit Member")
-
-        member_to_edit = None
-        if st.session_state.selected_member_id:
-            try:
-                member_data = api.get_member_by_id(st.session_state.selected_member_id)
-                if member_data:
-                    # member_data is (member_id, client_name, phone, join_date, is_active)
-                    member_to_edit = {
-                        "id": member_data[0],
-                        "name": member_data[1],
-                        "phone": member_data[2],
-                        "join_date": datetime.strptime(member_data[3], "%Y-%m-%d").date() if member_data[3] else date.today(),
-                        "status": "Active" if member_data[4] else "Inactive"
-                    }
-                else:
-                    st.error("Selected member not found.")
-                    st.session_state.selected_member_id = None # Reset
-            except Exception as e:
-                st.error(f"Error fetching member details: {e}")
-                st.session_state.selected_member_id = None # Reset
-
-
-        with st.form(key=st.session_state.form_key_member, clear_on_submit=True):
-            st.text_input("Member ID", value=member_to_edit["id"] if member_to_edit else "Auto-generated", disabled=True)
-            name = st.text_input("Name", value=member_to_edit["name"] if member_to_edit else "")
-            phone = st.text_input("Phone", value=member_to_edit["phone"] if member_to_edit else "")
-            join_date_val = st.date_input("Join Date", value=member_to_edit["join_date"] if member_to_edit else date.today())
-            status_options = ["Active", "Inactive"]
-            status = st.selectbox("Status", options=status_options, index=status_options.index(member_to_edit["status"]) if member_to_edit else 0)
-
-            col_save, col_clear = st.columns(2)
-            with col_save:
-                save_button = st.form_submit_button("Save Member")
-            with col_clear:
-                clear_button = st.form_submit_button("Clear / New")
-
-            if save_button:
-                is_active_bool = True if status == "Active" else False
-                join_date_str = join_date_val.strftime("%Y-%m-%d")
-
-                if not name or not phone:
-                    st.error("Name and Phone cannot be empty.")
-                else:
-                    try:
-                        if st.session_state.selected_member_id:
-                            success, message = api.update_member(st.session_state.selected_member_id, name, phone, join_date_str, is_active_bool)
-                        else:
-                            # Using add_member_with_join_date as it returns member_id, though not directly used here.
-                            # add_member also works.
-                            member_id_or_none = api.add_member_with_join_date(name, phone, join_date_str)
-                            if member_id_or_none: # Assuming returns ID on success, None on failure for this one
-                                success, message = True, "Member added successfully."
-                                # Manually set is_active for new members if add_member_with_join_date doesn't
-                                # This might require an update_member call if default is_active is not what's selected.
-                                # For simplicity, let's assume new members are active as per form, or add_member_with_join_date handles it.
-                                # Or, if add_member_with_join_date does not set is_active:
-                                # api.update_member(member_id_or_none, name, phone, join_date_str, is_active_bool)
-                            else: # Check how add_member_with_join_date signals error (e.g. phone exists)
-                                success, message = False, "Failed to add member. Phone might already exist or other error."
-                                # A more specific error might come from add_member if it returns Tuple[bool, str]
-                                # success, message = api.add_member(name, phone, join_date_str)
-                                # if success and is_active_bool == False: # if add_member defaults to active
-                                #    api.update_member(LAST_INSERT_ID_EQUIVALENT, name, phone, join_date_str, is_active_bool)
-
-
-                        if success:
-                            st.success(message)
-                            st.session_state.selected_member_id = None
-                            st.session_state.form_key_member = f"member_form_{datetime.now().timestamp()}" # Reset form
-                            st.rerun()
-                        else:
-                            st.error(message)
-                    except Exception as e:
-                        st.error(f"An error occurred: {e}")
-
-            if clear_button:
-                st.session_state.selected_member_id = None
-                st.session_state.form_key_member = f"member_form_{datetime.now().timestamp()}" # Reset form
-                st.rerun()
-
-    # Right Column: Members List & Filters
-    with right_column:
-        st.subheader("View Members")
-
-        search_name = st.text_input("Search by Name")
-        status_filter_options = ["All", "Active", "Inactive"]
-        status_filter = st.selectbox("Filter by Status", status_filter_options)
-
-        actual_status_filter = None
-        if status_filter == "Active":
-            actual_status_filter = "Active"
-        elif status_filter == "Inactive":
-            actual_status_filter = "Inactive"
-
-        try:
-            members_list = api.get_filtered_members(name_query=search_name if search_name else None, status=actual_status_filter)
-
-            if members_list:
-                member_data_for_df = []
-                for member in members_list:
-                    # (member_id, client_name, phone, join_date, is_active (bool))
-                    member_data_for_df.append({
-                        "ID": member[0],
-                        "Name": member[1],
-                        "Phone": member[2],
-                        "Join Date": member[3],
-                        "Status": "Active" if member[4] else "Inactive",
-                    })
-
-                df_members = pd.DataFrame(member_data_for_df)
-
-                # Displaying with st.dataframe for now. Adding buttons within dataframe is complex.
-                # A common pattern is to list items and have buttons next to them.
-                st.dataframe(df_members[['ID', 'Name', 'Phone', 'Join Date', 'Status']], hide_index=True, use_container_width=True)
-
-                for index, member in enumerate(members_list):
-                    member_id = member[0]
-                    member_name = member[1]
-                    cols = st.columns([2,1,1,1]) # Adjust ratios as needed
-                    cols[0].write(f"**{member_name}** (ID: {member_id})")
-
-                    if cols[1].button("Edit", key=f"edit_member_{member_id}"):
-                        st.session_state.selected_member_id = member_id
-                        st.session_state.form_key_member = f"member_form_{datetime.now().timestamp()}" # Ensure form rerenders with new defaults
-                        st.rerun()
-
-                    if cols[2].button("Delete", key=f"delete_member_{member_id}"):
-                        # Simple confirmation for now. st.confirm_dialog is not a standard feature.
-                        # Using a checkbox or a second button click could be alternatives.
-                        # For this subtask, direct deletion on button click.
-                        # Add st.confirm_dialog if available or use a different confirmation method later.
-                        st.warning(f"Are you sure you want to deactivate {member_name}? This action might be irreversible through the UI if not careful.")
-                        if st.button("Confirm Deactivate", key=f"confirm_delete_{member_id}"):
-                            try:
-                                success, message = api.deactivate_member(member_id)
-                                if success:
-                                    st.success(message)
-                                else:
-                                    st.error(message)
-                                st.rerun()
-                            except Exception as e:
-                                st.error(f"Error deactivating member: {e}")
-
-                    if cols[3].button("History", key=f"history_member_{member_id}"):
-                        st.session_state.history_member_id = member_id
-                        st.session_state.show_history_modal = True
-                        st.rerun()
-
-            else:
-                st.info("No members found matching your criteria.")
-
-        except Exception as e:
-            st.error(f"Failed to fetch members: {e}")
-
-    # Member History Modal/Dialog
-    if st.session_state.get('show_history_modal', False) and st.session_state.history_member_id is not None:
-        member_id_for_history = st.session_state.history_member_id
-        member_name_for_history = "Member" # Default
-        try:
-            # Fetch member name for the dialog title
-            hist_member_details = api.get_member_by_id(member_id_for_history)
-            if hist_member_details:
-                member_name_for_history = hist_member_details[1]
-        except Exception as e:
-            st.warning(f"Could not fetch member name for history dialog: {e}")
-
-        # Using st.dialog if available, otherwise a container. Streamlit's st.dialog is relatively new.
-        # For broader compatibility, an expander or just a section.
-        # Let's use a container that simulates a modal experience.
-        with st.container(): # This will just be part of the page flow.
-                             # True modal requires st.dialog (Streamlit 1.2 dialog or newer)
-                             # or more complex HTML/JS.
-            st.subheader(f"Transaction History for {member_name_for_history} (ID: {member_id_for_history})")
-            try:
-                history = api.get_all_activity_for_member(member_id_for_history)
-                if history:
-                    history_df_data = []
-                    total_amount = 0
-                    for item in history:
-                        # (transaction_id, transaction_type, description, transaction_date,
-                        #  start_date, end_date, amount, plan_name, payment_method, sessions)
-                        history_df_data.append({
-                            "Date": item[3], # transaction_date
-                            "Type": item[1], # transaction_type
-                            "Description": item[2],
-                            "Plan": item[7] if item[7] else "-", # plan_name
-                            "Amount": f"${item[6]:.2f}" if item[6] is not None else "-",
-                            "Start Date": item[4] if item[4] else "-",
-                            "End Date": item[5] if item[5] else "-",
-                        })
-                        if item[6] is not None:
-                            total_amount += item[6]
-
-                    history_df = pd.DataFrame(history_df_data)
-                    st.dataframe(history_df, hide_index=True, use_container_width=True)
-                    st.markdown(f"**Total Amount Paid: ${total_amount:.2f}**")
-                else:
-                    st.info("No transaction history found for this member.")
-            except Exception as e:
-                st.error(f"Failed to fetch transaction history: {e}")
-
-            if st.button("Close History", key="close_history_modal"):
-                st.session_state.show_history_modal = False
-                st.session_state.history_member_id = None
-                st.rerun()
-
-def render_plans_tab():
-    st.header("Plan Management")
-
-    # Initialize session state variables
-    if 'selected_plan_id' not in st.session_state:
-        st.session_state.selected_plan_id = None
-    if 'form_key_plan' not in st.session_state:
-        st.session_state.form_key_plan = 'initial_plan_form'
-
-    left_column, right_column = st.columns(2)
-
-    # Left Column: Add/Edit Plan Form
-    with left_column:
-        st.subheader("Add/Edit Plan")
-
-        plan_to_edit = None
-        if st.session_state.selected_plan_id:
-            try:
-                # (id, name, duration, price, type, is_active)
-                plan_data = api.get_plan_by_id(st.session_state.selected_plan_id)
-                if plan_data:
-                    plan_to_edit = {
-                        "id": plan_data[0],
-                        "name": plan_data[1],
-                        "duration": plan_data[2], # Assuming duration is in days
-                        "price": plan_data[3],
-                        "type": plan_data[4],
-                        "is_active": bool(plan_data[5])
-                    }
-                else:
-                    st.error("Selected plan not found.")
-                    st.session_state.selected_plan_id = None # Reset
-            except Exception as e:
-                st.error(f"Error fetching plan details: {e}")
-                st.session_state.selected_plan_id = None
-
-        with st.form(key=st.session_state.form_key_plan, clear_on_submit=True):
-            st.text_input("Plan ID", value=plan_to_edit["id"] if plan_to_edit else "Auto-generated", disabled=True)
-            name = st.text_input("Name", value=plan_to_edit["name"] if plan_to_edit else "")
-            # Duration is in days as per API
-            duration_days = st.number_input("Duration (days)", min_value=1, step=1, value=plan_to_edit["duration"] if plan_to_edit else 30)
-            price = st.number_input("Price", min_value=0.0, format="%.2f", value=plan_to_edit["price"] if plan_to_edit else 0.0)
-            plan_type_options = ["Group Class", "Personal Training", "Gym Access", "Other"] # Added "Other"
-            plan_type = st.selectbox("Type", options=plan_type_options, index=plan_type_options.index(plan_to_edit["type"]) if plan_to_edit and plan_to_edit["type"] in plan_type_options else 0)
-
-            is_active_checkbox = None
-            if st.session_state.selected_plan_id and plan_to_edit: # Only show for existing plans
-                is_active_checkbox = st.checkbox("Is Active", value=plan_to_edit["is_active"])
-
-            col_save, col_clear = st.columns(2)
-            with col_save:
-                save_button = st.form_submit_button("Save Plan")
-            with col_clear:
-                clear_button = st.form_submit_button("Clear / New")
-
-            if save_button:
-                if not name or duration_days <= 0 or price < 0 or not plan_type:
-                    st.error("Please fill in all required fields with valid values (Name, Duration > 0, Price >= 0, Type).")
-                else:
-                    try:
-                        if st.session_state.selected_plan_id:
-                            # For existing plans, use the checkbox value if available, otherwise keep current status (None means no change)
-                            is_active_val = is_active_checkbox if is_active_checkbox is not None else plan_to_edit.get('is_active') if plan_to_edit else True
-                            success, message = api.update_plan(st.session_state.selected_plan_id, name, int(duration_days), float(price), plan_type, is_active_val)
-                        else:
-                            # New plans are added as active by default (is_active=True implicitly or handled by API)
-                            # The current api.add_plan doesn't take is_active. Assume it defaults to active.
-                            success, message, _ = api.add_plan(name, int(duration_days), float(price), plan_type)
-
-                        if success:
-                            st.success(message)
-                            st.session_state.selected_plan_id = None
-                            st.session_state.form_key_plan = f"plan_form_{datetime.now().timestamp()}"
-                            st.rerun()
-                        else:
-                            st.error(message)
-                    except Exception as e:
-                        st.error(f"An error occurred: {e}")
-
-            if clear_button:
-                st.session_state.selected_plan_id = None
-                st.session_state.form_key_plan = f"plan_form_{datetime.now().timestamp()}"
-                st.rerun()
-
-    # Right Column: Plans List
-    with right_column:
-        st.subheader("View Plans")
-        try:
-            plans_list = api.get_all_plans() # (id, name, duration, price, type, is_active)
-            if plans_list:
-                plan_data_for_df = []
-                for plan_tuple in plans_list:
-                    plan_data_for_df.append({
-                        "ID": plan_tuple[0],
-                        "Name": plan_tuple[1],
-                        "Duration (Days)": plan_tuple[2],
-                        "Price": f"${plan_tuple[3]:.2f}",
-                        "Type": plan_tuple[4],
-                        "Status": "Active" if bool(plan_tuple[5]) else "Inactive"
-                    })
-                df_plans = pd.DataFrame(plan_data_for_df)
-                st.dataframe(df_plans[['ID', 'Name', 'Duration (Days)', 'Price', 'Type', 'Status']], hide_index=True, use_container_width=True)
-
-                for index, plan_tuple in enumerate(plans_list):
-                    plan_id = plan_tuple[0]
-                    plan_name = plan_tuple[1]
-                    is_plan_active = bool(plan_tuple[5])
-
-                    cols_actions = st.columns([3,1,1,1]) # Name | Edit | Delete | Toggle
-                    cols_actions[0].write(f"**{plan_name}** (ID: {plan_id})")
-
-                    if cols_actions[1].button("Edit", key=f"edit_plan_{plan_id}"):
-                        st.session_state.selected_plan_id = plan_id
-                        st.session_state.form_key_plan = f"plan_form_{datetime.now().timestamp()}"
-                        st.rerun()
-
-                    # Delete button with confirmation
-                    if cols_actions[2].button("Delete", key=f"delete_plan_{plan_id}"):
-                        st.session_state[f"confirm_delete_plan_{plan_id}"] = True # Flag for confirmation
-                        st.rerun()
-
-                    if st.session_state.get(f"confirm_delete_plan_{plan_id}", False):
-                        st.warning(f"Are you sure you want to delete plan '{plan_name}' (ID: {plan_id})? This cannot be undone if transactions use this plan.")
-                        confirm_col1, confirm_col2 = st.columns(2)
-                        if confirm_col1.button("Yes, Delete Plan", key=f"confirm_delete_btn_plan_{plan_id}"):
-                            try:
-                                success, message = api.delete_plan(plan_id)
-                                if success:
-                                    st.success(message)
-                                else:
-                                    st.error(message)
-                                del st.session_state[f"confirm_delete_plan_{plan_id}"]
-                                st.rerun()
-                            except Exception as e:
-                                st.error(f"Error deleting plan: {e}")
-                                del st.session_state[f"confirm_delete_plan_{plan_id}"]
-                                st.rerun()
-                        if confirm_col2.button("Cancel", key=f"cancel_delete_plan_{plan_id}"):
-                            del st.session_state[f"confirm_delete_plan_{plan_id}"]
-                            st.rerun()
-
-                    # Toggle Active button
-                    toggle_button_text = "Deactivate" if is_plan_active else "Activate"
-                    if cols_actions[3].button(toggle_button_text, key=f"toggle_plan_{plan_id}"):
-                        try:
-                            # We need all plan details to update, even if only status changes
-                            # Or create a specific api.update_plan_status(plan_id, new_status)
-                            # For now, using the modified update_plan
-                            success, message = api.update_plan(plan_id, plan_tuple[1], plan_tuple[2], plan_tuple[3], plan_tuple[4], is_active=not is_plan_active)
-                            if success:
-                                st.success(f"Plan '{plan_name}' status changed.")
-                            else:
-                                st.error(f"Failed to change plan status: {message}")
-                            st.rerun()
-                        except Exception as e:
-                             st.error(f"Error toggling plan status: {e}")
-
-            else:
-                st.info("No plans found. Add some plans using the form on the left.")
-        except Exception as e:
-            st.error(f"Failed to fetch plans: {e}")
+# render_members_tab and render_plans_tab have been removed.
 
 def render_reporting_tab():
     st.header("Financial & Renewals Reporting")
 
     # Initialize session state variables
-    if 'monthly_report_data' not in st.session_state:
-        st.session_state.monthly_report_data = None
-    if 'monthly_report_summary' not in st.session_state:
-        st.session_state.monthly_report_summary = None
+    if 'financial_report_output' not in st.session_state: # Updated state variable
+        st.session_state.financial_report_output = None
     if 'renewals_report_data' not in st.session_state:
         st.session_state.renewals_report_data = None
     # Default to current month for date inputs
@@ -733,51 +388,47 @@ def render_reporting_tab():
     if report_month_financial_val != st.session_state.report_month_financial:
         st.session_state.report_month_financial = report_month_financial_val
         # Clear old report data when month changes before generating new one
-        st.session_state.monthly_report_data = None
-        st.session_state.monthly_report_summary = None
+        st.session_state.financial_report_output = None # Clear combined state
 
 
     if st.button("Generate Monthly Financial Report", key="generate_financial_report"):
         year = st.session_state.report_month_financial.year
         month = st.session_state.report_month_financial.month
         try:
-            st.session_state.monthly_report_data = api.get_transactions_for_month(year, month)
-            st.session_state.monthly_report_summary = api.get_finance_report(year, month)
+            # Call the new unified financial report function
+            report_output = get_financial_summary_report(DB_FILE, year, month)
+            st.session_state.financial_report_output = report_output
 
-            if st.session_state.monthly_report_summary is None and not st.session_state.monthly_report_data:
+            if not report_output or (report_output.get('summary', {}).get('total_income', 0) == 0 and not report_output.get('transactions')):
                  st.info(f"No financial data found for {st.session_state.report_month_financial.strftime('%B %Y')}.")
             else:
                  st.success(f"Financial report generated for {st.session_state.report_month_financial.strftime('%B %Y')}.")
         except Exception as e:
             st.error(f"Error generating financial report: {e}")
-            st.session_state.monthly_report_data = None
-            st.session_state.monthly_report_summary = None
+            st.session_state.financial_report_output = None
 
-    if st.session_state.monthly_report_summary is not None:
+    if st.session_state.financial_report_output:
+        summary_data = st.session_state.financial_report_output.get('summary', {})
+        transactions_data = st.session_state.financial_report_output.get('transactions', [])
+
         st.metric(
             label=f"Total Income for {st.session_state.report_month_financial.strftime('%B %Y')}",
-            value=f"${st.session_state.monthly_report_summary:.2f}"
+            value=f"${summary_data.get('total_income', 0.0):.2f}"
         )
+        # Optionally, display other summary points like total transactions, new members etc.
+        # For example:
+        # st.metric(label="Total Transactions", value=summary_data.get('total_transactions', 0))
 
-    if st.session_state.monthly_report_data:
-        # API returns: (transaction_id, client_name, transaction_date, start_date, end_date, amount, transaction_type, description, plan_name, payment_method, sessions)
-        df_financial_data = []
-        for item in st.session_state.monthly_report_data:
-            df_financial_data.append({
-                "Tx ID": item[0],
-                "Member Name": item[1],
-                "Tx Date": item[2],
-                "Amount": f"${item[5]:.2f}" if item[5] is not None else "-",
-                "Type": item[6],
-                "Description": item[7],
-                "Plan Name": item[8] if item[8] else "N/A",
-                "Payment Method": item[9] if item[9] else "N/A"
-            })
-        df_financial = pd.DataFrame(df_financial_data)
-        st.dataframe(df_financial, hide_index=True, use_container_width=True)
-    elif st.session_state.monthly_report_summary is not None and not st.session_state.monthly_report_data :
-        # This case handles when summary is 0.0 (or some value) but no detailed transactions
-        st.info(f"No detailed transactions found for {st.session_state.report_month_financial.strftime('%B %Y')}, though summary is calculated.")
+        if transactions_data:
+            # Assuming transactions_data is a list of dicts with keys like
+            # 'transaction_id', 'client_name', 'transaction_date', 'amount', 'transaction_type', etc.
+            df_financial = pd.DataFrame(transactions_data)
+            # Adjust columns based on actual keys in transactions_data
+            # Example:
+            st.dataframe(df_financial[['transaction_id', 'client_name', 'transaction_date', 'amount', 'transaction_type', 'description', 'plan_name', 'payment_method']], hide_index=True, use_container_width=True)
+        elif summary_data.get('total_income', 0) > 0 :
+             st.info(f"Summary available, but no detailed transactions found for {st.session_state.report_month_financial.strftime('%B %Y')}.")
+        # If both summary and transactions are empty, the initial "No financial data found" message covers it.
 
 
     st.divider()
@@ -800,7 +451,8 @@ def render_reporting_tab():
         year = st.session_state.report_month_renewals.year
         month = st.session_state.report_month_renewals.month
         try:
-            st.session_state.renewals_report_data = api.get_pending_renewals(year, month)
+            # Call the new renewal forecast function
+            st.session_state.renewals_report_data = get_renewal_forecast_report(DB_FILE, year, month)
             if not st.session_state.renewals_report_data: # Empty list means no renewals
                 st.info(f"No upcoming renewals found for {st.session_state.report_month_renewals.strftime('%B %Y')}.")
             else:
@@ -810,32 +462,23 @@ def render_reporting_tab():
             st.session_state.renewals_report_data = None # Set to None on error
 
     if st.session_state.renewals_report_data: # Check if data exists (could be an empty list)
-        # API returns: (client_name, phone, plan_name, end_date)
-        df_renewals_data = []
-        for item in st.session_state.renewals_report_data:
-            df_renewals_data.append({
-                "Member Name": item[0],
-                "Phone": item[1],
-                "Plan Name": item[2],
-                "End Date": item[3]
-            })
-        df_renewals = pd.DataFrame(df_renewals_data)
-        st.dataframe(df_renewals, hide_index=True, use_container_width=True)
+        # Assuming get_renewal_forecast_report returns a list of dicts with keys like
+        # 'client_name', 'phone', 'plan_name', 'end_date', 'renewal_status' (example new field)
+        df_renewals = pd.DataFrame(st.session_state.renewals_report_data)
+        # Adjust columns based on actual keys in the returned data
+        # Example:
+        st.dataframe(df_renewals[['client_name', 'phone', 'plan_name', 'end_date']], hide_index=True, use_container_width=True)
     # Handle case where button was clicked, data is explicitly an empty list (meaning no renewals found)
-    elif st.session_state.renewals_report_data == []:
+    elif st.session_state.renewals_report_data == []: # Explicitly check for empty list
          st.info(f"No upcoming renewals found for {st.session_state.report_month_renewals.strftime('%B %Y')}.")
 
 
-tab_memberships, tab_members, tab_plans, tab_reporting = st.tabs(["Memberships", "Members", "Plans", "Reporting"])
+tab_memberships, tab_reporting = st.tabs(["Memberships", "Reporting"])
 
 with tab_memberships:
     render_memberships_tab()
 
-with tab_members:
-    render_members_tab()
-
-with tab_plans:
-    render_plans_tab()
+# Removed tab_members and tab_plans sections
 
 with tab_reporting:
     render_reporting_tab()


### PR DESCRIPTION
This commit updates the Streamlit application (`reporter/streamlit_ui/app.py`), focusing on UI/UX refactoring:

- **Reporting Tab:**
    - I modified `render_reporting_tab` to use the new standalone reporting functions (`get_financial_summary_report` and `get_renewal_forecast_report`).
    - I adjusted the UI to correctly display data from these new functions.

- **Memberships Tab:**
    - I updated `render_memberships_tab` so that when a plan is selected, its duration is displayed (read-only). This relies on `get_active_plans_for_dropdown` returning duration information.
    - I verified that the `SAVE` button correctly calls the refactored `create_membership` API.

- **Removed Tabs:**
    - I deleted the `render_members_tab` and `render_plans_tab` functions.
    - I removed the "Members" and "Plans" tabs from the UI, as their direct CRUD functionality is no longer needed. The primary workflow is now centered around the "Memberships" tab.