### PR TITLE
Fix: Remove extra parameter in pt_memberships check

### DIFF
--- a/reporter/migrate_historical_data.py
+++ b/reporter/migrate_historical_data.py
@@ -261,7 +261,7 @@ def migrate_pt_data(db_mngr: DatabaseManager, processed_members: dict, earliest_
                 cursor_check.execute("""
                     SELECT id FROM pt_memberships
                     WHERE member_id = ? AND purchase_date = ? AND amount_paid = ? AND sessions_total = ? AND notes = ? AND sessions_remaining = ?
-                """, (member_id, purchase_date, amount_paid, sessions_purchased, '', sessions_purchased))
+                """, (member_id, purchase_date, amount_paid, sessions_purchased, sessions_purchased))
                 if cursor_check.fetchone():
                     logging.info(f"Skipping existing PT record for member_id {member_id} on {purchase_date}")
                     continue


### PR DESCRIPTION
I removed an erroneous empty string parameter from the tuple in the `cursor_check.execute` call within the `migrate_pt_data` function. This call checks for existing PT memberships before inserting a new one. The extra parameter caused the check to potentially not find existing records correctly.