### PR TITLE
Fix: Ensure group_class_memberships schema and improve price parsing

### DIFF
--- a/reporter/database.py
+++ b/reporter/database.py
@@ -44,6 +44,7 @@ def create_database(db_name: str):
         )
 
         # Create group_class_memberships table
+        cursor.execute("DROP TABLE IF EXISTS group_class_memberships;") # Added this line
         cursor.execute(
             """
         CREATE TABLE IF NOT EXISTS group_class_memberships (


### PR DESCRIPTION
Resolves sqlite3.OperationalError for ON CONFLICT clause by ensuring the group_class_memberships table is dropped and recreated during migration, guaranteeing the UNIQUE constraint is present.

Improves robustness of price parsing in GC data migration:
- Handles Python None or string 'None' for 'Amount' field.
- Sets price to 0.0 if amount is missing, 'None', or becomes empty/hyphen after cleaning.
- Logs clearer warnings for price parsing issues.