### PR TITLE
Fix: Resolve ImportError in main.py and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Once the setup and data migration are complete, you can run the application.
 Execute the following command from the project's root directory. This will start the web server and open the application in your default browser.
 
 ```bash
-streamlit run reporter/main.py
+python -m streamlit run reporter/main.py
 ```
 
 ## Running Tests (For Developers)

--- a/reporter/main.py
+++ b/reporter/main.py
@@ -13,8 +13,8 @@ import importlib.util
 import subprocess
 # os and sys were already imported by the new snippet
 
-from .database import DB_FILE, initialize_database  # Updated database import
-from .migrate_historical_data import migrate_historical_data
+from reporter.database import DB_FILE, initialize_database  # Updated database import
+from reporter.migrate_historical_data import migrate_historical_data
 
 # Removed old imports:
 # import sqlite3 # No longer directly used here


### PR DESCRIPTION
- I changed relative imports in reporter/main.py to absolute imports to resolve "ImportError: attempted relative import with no known parent package". The script sys.path modification allows these absolute imports from the project root.
- I updated README.md to reflect the correct command for running the Streamlit application: `python -m streamlit run reporter/main.py`.